### PR TITLE
Fixed fan attribute when slider value is set

### DIFF
--- a/slider-card.js
+++ b/slider-card.js
@@ -175,7 +175,7 @@ render() {
     return html`
         <ha-card>
           <div class="slider-container" style="${styleStr}">
-            <input name="foo" type="range" class="${entityClass.state}" style="${styleStr}" .value="${entityClass.attributes.current_position}" min="0" max="100" step="${step}" @change=${e => this._setFan(entityClass, e.target.value)}>
+            <input name="foo" type="range" class="${entityClass.state}" style="${styleStr}" .value="${entityClass.attributes.percentage}" min="0" max="100" step="${step}" @change=${e => this._setFan(entityClass, e.target.value)}>
           </div>
         </ha-card>
     `;


### PR DESCRIPTION
Fix the issue with the slider being reset on state change.

The attribute "current_position" as far as I am aware is unused on fan antities and was returning "undefined".