### PR TITLE
Define min max

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Everything under function in the options table is css styling, so it is possible
 | ---- | ---- | ------- | ----------- |
 | type | string | **Required** | `custom:slider-card` |
 | entity | string | **Required** | `light.living_room` |
+|minValue| int | 0 | Set minium slider value for `media_player`, `fan`, and `cover` entities |
+|maxValue| int | 100 | Set maximum slider value for `media_player`, `fan`, and `cover` entities |
 | step | string | "1" | Number of steps to take (For input number, if step is not specified, it will use step from attributes.) (For media_player, if step is not specified it will step by 0.01. (It will actually step by 1, but it will convert 27 to 0.27. So if you set a custom step, set it between 0 and 100.)) |
 | radius | string | "4px" | Border radius of slider. |
 | function | string | "Brightness" | Function of the slider (Brightness/Warmth) |

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Everything under function in the options table is css styling, so it is possible
 | ---- | ---- | ------- | ----------- |
 | type | string | **Required** | `custom:slider-card` |
 | entity | string | **Required** | `light.living_room` |
-|minValue| int | 0 | Set minium slider value for `media_player`, `fan`, and `cover` entities |
+|minValue| int | 0 | Set minimum slider value for `media_player`, `fan`, and `cover` entities |
 |maxValue| int | 100 | Set maximum slider value for `media_player`, `fan`, and `cover` entities |
 | step | string | "1" | Number of steps to take (For input number, if step is not specified, it will use step from attributes.) (For media_player, if step is not specified it will step by 0.01. (It will actually step by 1, but it will convert 27 to 0.27. So if you set a custom step, set it between 0 and 100.)) |
 | radius | string | "4px" | Border radius of slider. |

--- a/slider-card.js
+++ b/slider-card.js
@@ -20,6 +20,8 @@ constructor() {
 
 render() {
   // Size Variables
+  var minValue = this.config.minValue ? this.config.minValue : "0";
+  var maxValue = this.config.maxValue ? this.config.maxValue : "100";
   var width = this.config.width ? this.config.width : "100%";
   var height = this.config.height ? this.config.height : "50px";
   var radius = this.config.radius ? this.config.radius : "4px";
@@ -155,7 +157,7 @@ render() {
     return html`
         <ha-card>
           <div class="slider-container" style="${styleStr}">
-            <input name="foo" type="range" class="${entityClass.state}" style="${styleStr}" .value="${num}" min="0" max="100" step="${step}" @change=${e => this._setMediaVolume(entityClass, e.target.value)}>
+            <input name="foo" type="range" class="${entityClass.state}" style="${styleStr}" .value="${num}" min="${minValue}" max="${maxValue}" step="${step}" @change=${e => this._setMediaVolume(entityClass, e.target.value)}>
           </div>
         </ha-card>
     `;
@@ -165,7 +167,7 @@ render() {
     return html`
         <ha-card>
           <div class="slider-container" style="${styleStr}">
-            <input name="foo" type="range" class="${entityClass.state}" style="${styleStr}" .value="${entityClass.attributes.current_position}" min="0" max="100" step="${step}" @change=${e => this._setCover(entityClass, e.target.value)}>
+            <input name="foo" type="range" class="${entityClass.state}" style="${styleStr}" .value="${entityClass.attributes.current_position}" min="${minValue}" max="${maxValue}" step="${step}" @change=${e => this._setCover(entityClass, e.target.value)}>
           </div>
         </ha-card>
     `;
@@ -175,7 +177,7 @@ render() {
     return html`
         <ha-card>
           <div class="slider-container" style="${styleStr}">
-            <input name="foo" type="range" class="${entityClass.state}" style="${styleStr}" .value="${entityClass.attributes.percentage}" min="0" max="100" step="${step}" @change=${e => this._setFan(entityClass, e.target.value)}>
+            <input name="foo" type="range" class="${entityClass.state}" style="${styleStr}" .value="${entityClass.attributes.percentage}" min="${minValue}" max="${maxValue}" step="${step}" @change=${e => this._setFan(entityClass, e.target.value)}>
           </div>
         </ha-card>
     `;


### PR DESCRIPTION
Allow user configurable min/max values for media_player, fan, and cover entities.

Only really useful for media_player entities really. Helps with accidental volume bumps to max volume.