### PR TITLE
Fix: Hide shadow-box overflow in container

### DIFF
--- a/slider-card.js
+++ b/slider-card.js
@@ -386,6 +386,8 @@ static get styles() {
       .slider-container {
           height: var(--container-height);
           position: relative;
+          overflow: hidden;
+          border-radius: var(--slider-radius);
       }
 
       .slider-container input[type="range"] {


### PR DESCRIPTION
This only seemed to be an issue when a lot of transparent cards are used in a popup.

Tested on iOS, Firefox, Chrome.
